### PR TITLE
Make codecov secret optional

### DIFF
--- a/.github/workflows/rules-poetry.yml
+++ b/.github/workflows/rules-poetry.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
         default: false
     secrets:
-      CODECOV_TOKEN:
+      codecov_token:
         required: false
 
 jobs:

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -1,29 +1,28 @@
 name: Rules
 
 on:
-
   workflow_call:
     inputs:
-        os:
-          required: true
-          type: string
-        python-version:
-          required: true
-          type: string
-        environment:
-          required: true
-          type: string
-        pip-extras:
-          required: false
-          type: string
-          default: " "
-        doctests:
-          required: false
-          type: boolean
-          default: false
+      os:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+      pip-extras:
+        required: false
+        type: string
+        default: " "
+      doctests:
+        required: false
+        type: boolean
+        default: false
     secrets:
       CODECOV_TOKEN:
-        required: true
+        required: false
 
 jobs:
   build:
@@ -32,45 +31,45 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ inputs.python-version }}
-    - name: Install package
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest-cov
-        pip install pytest-env
-        pip install ".[${{ inputs.pip-extras }}]"
-        if [[ "${{ inputs.environment }}" == "qibo" ]]; then
-          pip install git+https://github.com/qiboteam/qibojit
-          pip install tensorflow
-        fi
-        if [[ "${{ inputs.environment }}" == "qibolab" || \
-              "${{ inputs.environment }}" == "qibojit" ]]; then
-          pip install git+https://github.com/qiboteam/qibo
-        fi
-        pip install pylint
-    - name: Test with pylint
-      run: |
-        pylint src --errors-only
-        pylint src --exit-zero
-    - name: Test with pytest core
-      run: |
-        pytest
-    - name: Test example
-      if: ${{ inputs.doctests }}
-      run: |
-        sudo apt install pandoc
-        make -C doc doctest
-        OMP_NUM_THREADS=1 pytest examples/
-    - name: Upload coverage to Codecov
-      if: startsWith(runner.os, 'Linux')
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests
-        name: unit-tests
-        fail_ci_if_error: true
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest-cov
+          pip install pytest-env
+          pip install ".[${{ inputs.pip-extras }}]"
+          if [[ "${{ inputs.environment }}" == "qibo" ]]; then
+            pip install git+https://github.com/qiboteam/qibojit
+            pip install tensorflow
+          fi
+          if [[ "${{ inputs.environment }}" == "qibolab" || \
+                "${{ inputs.environment }}" == "qibojit" ]]; then
+            pip install git+https://github.com/qiboteam/qibo
+          fi
+          pip install pylint
+      - name: Test with pylint
+        run: |
+          pylint src --errors-only
+          pylint src --exit-zero
+      - name: Test with pytest core
+        run: |
+          pytest
+      - name: Test example
+        if: ${{ inputs.doctests }}
+        run: |
+          sudo apt install pandoc
+          make -C doc doctest
+          OMP_NUM_THREADS=1 pytest examples/
+      - name: Upload coverage to Codecov
+        if: startsWith(runner.os, 'Linux')
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+          name: unit-tests
+          fail_ci_if_error: true

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -21,7 +21,7 @@ on:
         type: boolean
         default: false
     secrets:
-      CODECOV_TOKEN:
+      codecov_token:
         required: false
 
 jobs:
@@ -68,7 +68,7 @@ jobs:
         if: startsWith(runner.os, 'Linux')
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.codecov_token }}
           file: ./coverage.xml
           flags: unittests
           name: unit-tests


### PR DESCRIPTION
Part of this has already been applied in ab09914

Following:
https://docs.codecov.com/docs/frequently-asked-questions/#where-is-the-repository-upload-token-found
we know that `CODECOV_TOKEN` is not required for public repos, so we were adding an unneeded constraint.

The repos have more or less all a `CODECOV_TOKEN`, so this was not a problem. But Dependabot has no access to repo secrets (since usually you don't want to give your secrets to an external bot):
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot
so we might have issues like https://github.com/qiboteam/qibocal/pull/238#issuecomment-1422171191 that are generated only by requiring this secret in the workflow.

- [x] fix the workflow not to require `CODECOV_TOKEN`
- ~~update docs~~ #35

P.S.: note that secrets are case insensitive, so this generates no issue